### PR TITLE
WL-3379 : roster should be called site members

### DIFF
--- a/roster-app/src/webapp/tools/sakai.site.roster.xml
+++ b/roster-app/src/webapp/tools/sakai.site.roster.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <registration>
-    <tool id="sakai.site.roster2" title="Roster" description="For viewing the site participants list">
+    <tool id="sakai.site.roster2" title="Site Members" description="For viewing the site participants list">
         <category name="course" />
 		<category name="project" />
        <category name="portfolio" />


### PR DESCRIPTION
Does both LHS and Edit Site Tools
